### PR TITLE
fix: restore request body after reading in auth handlers

### DIFF
--- a/server/internal/handlers/auth.go
+++ b/server/internal/handlers/auth.go
@@ -2,6 +2,7 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -45,7 +46,10 @@ func LoginHandler(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "Error reading request body", http.StatusBadRequest)
 				return
 			}
-			defer r.Body.Close()
+
+			// Restore the request body so it can be read by other handlers
+			r.Body.Close()
+			r.Body = io.NopCloser(bytes.NewBuffer(body))
 
 			// Decode JSON
 			if err := json.Unmarshal(body, &loginData); err != nil {

--- a/server/internal/middleware/auth.go
+++ b/server/internal/middleware/auth.go
@@ -2,6 +2,7 @@
 package middleware
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -61,7 +62,9 @@ func AuthMiddleware(next http.Handler) http.Handler {
 				// Limit request body size to prevent DoS attacks
 				body, err := io.ReadAll(io.LimitReader(r.Body, 1024))
 				if err == nil {
-					defer r.Body.Close()
+					// Restore the request body so it can be read by other handlers
+					r.Body.Close()
+					r.Body = io.NopCloser(bytes.NewBuffer(body))
 
 					// Decode JSON
 					if err := json.Unmarshal(body, &loginData); err == nil {


### PR DESCRIPTION
- Fixed request body consumption in both handlers/auth.go and middleware/auth.go
- Added bytes import for buffer operations
- Ensured request body can be read by subsequent handlers
- Added task completion documentation